### PR TITLE
Fix an error when a refetchQuery wasn't defined

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -174,7 +174,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
     // refetch.
     if (refetchQueries && refetchQueries.length && Array.isArray(refetchQueries)) {
       refetchQueries = (refetchQueries as any).map((x: string | PureQueryOptions) => {
-        if (typeof x === 'string' && this.context.operations) return this.context.operations.get(x);
+        if (typeof x === 'string' && this.context.operations) return this.context.operations.get(x) || x;
         return x;
       });
       delete options.refetchQueries;


### PR DESCRIPTION
When we are searching a query to refetch, we must take care to return the operation, if it exists, else we must return the original string.
The code in apollo-client does not handle a query equal to "undefined" but takes care of the string if properly forwarded to. See ahttps://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/QueryManager.ts l254.

How to reproduce the bug:

* provide a unknown query as a string in the options of a mutation. (ex: refetchQueries: ['test'])
* Run the mutation
* Instead of ignoring the query, apollo with throw an error: Uncaught TypeError: Cannot read property 'query' of undefined at QueryManager.js:143

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->